### PR TITLE
Fix default property for constrained_annotations

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -81,4 +81,3 @@ annotations:
       operations:
       - CREATE
       - UPDATE
-

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,27 +4,27 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.6
+version: 0.2.7
 name: safe-annotations
 displayName: Safe Annotations
-createdAt: 2023-03-24T16:43:15.912355753Z
+createdAt: 2023-03-30T16:24:50.376773167Z
 description: A policy that validates Kubernetes' resource annotations
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/safe-annotations-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/safe-annotations:v0.2.6
+  image: ghcr.io/kubewarden/policies/safe-annotations:v0.2.7
 keywords:
 - annotations
 links:
 - name: policy
-  url: https://github.com/kubewarden/safe-annotations-policy/releases/download/v0.2.6/policy.wasm
+  url: https://github.com/kubewarden/safe-annotations-policy/releases/download/v0.2.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/safe-annotations-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/safe-annotations:v0.2.6
+  kwctl pull ghcr.io/kubewarden/policies/safe-annotations:v0.2.7
   ```
 maintainers:
 - name: Kubewarden developers
@@ -63,7 +63,7 @@ annotations:
       target: true
       type: array[
       variable: mandatory_annotations
-    - default: []
+    - default: {}
       tooltip: Annotations that are validated with user-defined RegExp
       group: Settings
       label: Constrained annotations
@@ -81,3 +81,4 @@ annotations:
       operations:
       - CREATE
       - UPDATE
+

--- a/questions-ui.yml
+++ b/questions-ui.yml
@@ -25,7 +25,7 @@ questions:
   target: true
   type: array[
   variable: mandatory_annotations
-- default: []
+- default: {}
   tooltip: Annotations that are validated with user-defined RegExp
   group: Settings
   label: Constrained annotations


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/ui/issues/307

This updates the default property for `constrained_annotations` in the `questions-ui.yml` to have the correct type. Bumps to version `0.2.7`
