### PR TITLE
Bump v0.2.8 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,27 +4,27 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.7
+version: 0.2.8
 name: safe-annotations
 displayName: Safe Annotations
-createdAt: 2023-03-30T16:24:50.376773167Z
+createdAt: 2023-07-07T18:51:34.299402705Z
 description: A policy that validates Kubernetes' resource annotations
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/safe-annotations-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/safe-annotations:v0.2.7
+  image: ghcr.io/kubewarden/policies/safe-annotations:v0.2.8
 keywords:
 - annotations
 links:
 - name: policy
-  url: https://github.com/kubewarden/safe-annotations-policy/releases/download/v0.2.7/policy.wasm
+  url: https://github.com/kubewarden/safe-annotations-policy/releases/download/v0.2.8/policy.wasm
 - name: source
   url: https://github.com/kubewarden/safe-annotations-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/safe-annotations:v0.2.7
+  kwctl pull ghcr.io/kubewarden/policies/safe-annotations:v0.2.8
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.2.8 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.2.8

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
