### PR TITLE
tests: fix failing e2e test

### DIFF
--- a/e2e.bats
+++ b/e2e.bats
@@ -114,6 +114,6 @@
   # settings validation fails
   [ "$status" -eq 1 ]
   [ $(expr "$output" : '.*valid.*false') -ne 0 ]
-  [ $(expr "$output" : ".*Provided settings are not valid: Cannot compile regexp.*") -ne 0 ]
+  [ $(expr "$output" : ".*Provided settings are not valid: error parsing regexp: missing closing.*") -ne 0 ]
 }
 


### PR DESCRIPTION
## Description

Fixes failing e2e tests due to a change in the error message when a regexp is not valid.

## Test

Yes

## Additional Information

### Potential improvement

Shouldn't the CI catch this when opening a PR?