### PR TITLE
chore(deps): tinygo v0.39.0 update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ policy.wasm: $(SOURCE_FILES) go.mod go.sum
 		--rm \
 		-e GOFLAGS="-buildvcs=false" \
 		-v ${PWD}:/src \
-		-w /src tinygo/tinygo:0.35.0 \
+		-w /src tinygo/tinygo:0.39.0 \
 		tinygo build -o policy.wasm -target=wasi -no-debug .
 
 


### PR DESCRIPTION
## Description

To be possible to update the golang version to v1.25 it's necessary to bump the Tinygo version to v0.39.0.

